### PR TITLE
Compatibility fix for LWM's Deep Storage

### DIFF
--- a/Source/DualWield/Harmony/FloatMenuMakerMap.cs
+++ b/Source/DualWield/Harmony/FloatMenuMakerMap.cs
@@ -39,14 +39,11 @@ namespace DualWield.Harmony
                         if (thingList[i].TryGetComp<CompEquippable>() != null)
                         {
                             equipment = (ThingWithComps)thingList[i];
-                            break;
+                            FloatMenuOption equipOffHandOption = GetEquipOffHandOption(pawn, equipment);
+                            opts.Add(equipOffHandOption);
                         }
                     }
-                    if (equipment != null)
-                    {
-                        FloatMenuOption equipOffHandOption = GetEquipOffHandOption(pawn, equipment);
-                        opts.Add(equipOffHandOption);
-                    }
+
                 }
             }
         }


### PR DESCRIPTION
Fixes problem where pawn right-clicking on Storage with multiple items in the same cell only has option to select first weapon.