### PR TITLE
Slightly faster private field access

### DIFF
--- a/Source/DualWield/Harmony/PawnRenderer.cs
+++ b/Source/DualWield/Harmony/PawnRenderer.cs
@@ -44,15 +44,14 @@ namespace DualWield.Harmony
             }
         }
         */
-        static bool Prefix(PawnRenderer __instance, Thing eq, ref Vector3 drawLoc, ref float aimAngle)
+        static bool Prefix(PawnRenderer __instance, Pawn ___pawn, Thing eq, ref Vector3 drawLoc, ref float aimAngle)
         {
             ThingWithComps offHandEquip = null;
-            Pawn pawn = Traverse.Create(__instance).Field("pawn").GetValue<Pawn>();
-            if (pawn.equipment == null)
+            if (___pawn.equipment == null)
             {
                 return true;
             }
-            if (pawn.equipment.TryGetOffHandEquipment(out ThingWithComps result))
+            if (___pawn.equipment.TryGetOffHandEquipment(out ThingWithComps result))
             {
                 offHandEquip = result;
             }
@@ -62,11 +61,11 @@ namespace DualWield.Harmony
             }
             float mainHandAngle = aimAngle;
             float offHandAngle = aimAngle;
-            Stance_Busy mainStance = pawn.stances.curStance as Stance_Busy;
+            Stance_Busy mainStance = ___pawn.stances.curStance as Stance_Busy;
             Stance_Busy offHandStance = null;
-            if (pawn.GetStancesOffHand() != null)
+            if (___pawn.GetStancesOffHand() != null)
             {
-                offHandStance = pawn.GetStancesOffHand().curStance as Stance_Busy;
+                offHandStance = ___pawn.GetStancesOffHand().curStance as Stance_Busy;
             }
             LocalTargetInfo focusTarg = null;
             if (mainStance != null && !mainStance.neverAimWeapon)
@@ -86,9 +85,9 @@ namespace DualWield.Harmony
             //bool currentlyAiming = (mainStance != null && !mainStance.neverAimWeapon && mainStance.focusTarg.IsValid) || stancesOffHand.curStance is Stance_Busy ohs && !ohs.neverAimWeapon && ohs.focusTarg.IsValid;
             //When wielding offhand weapon, facing south, and not aiming, draw differently 
 
-            SetAnglesAndOffsets(eq, offHandEquip, aimAngle, pawn, ref offsetMainHand, ref offsetOffHand, ref mainHandAngle, ref offHandAngle, mainHandAiming, offHandAiming);
+            SetAnglesAndOffsets(eq, offHandEquip, aimAngle, ___pawn, ref offsetMainHand, ref offsetOffHand, ref mainHandAngle, ref offHandAngle, mainHandAiming, offHandAiming);
 
-            if (offHandEquip != pawn.equipment.Primary)
+            if (offHandEquip != ___pawn.equipment.Primary)
             {
                 //drawLoc += offsetMainHand;
                 //aimAngle = mainHandAngle;


### PR DESCRIPTION
newest Harmony allows accessing private fields by the naming convention ___pawn; it should be slightly faster than calling Traverse.Create&c every time the screen refreshes.